### PR TITLE
Implement NotificationInterface, code and validate signature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
-  - hhvm
+  - 7.0
+  - 7.1
+  - 7.2
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
 
 before_script:
   - composer install -n --dev --prefer-source

--- a/README.md
+++ b/README.md
@@ -28,3 +28,51 @@ The following gateways are provided by this package:
 
 For general usage instructions, please see the main [Omnipay](https://github.com/thephpleague/omnipay)
 repository.
+
+## Example usage:
+
+Initialize gateway:
+```php
+$gateway = Omnipay::create('Dotpay');
+
+// Gateway specific parameters
+$gateway->initialize([
+    'accountId'  => 'YOUR_DOTPAY_ID',
+    'pid'        => 'YOUR_SECRET_PIN',
+    'type'       => '3',
+    'action'     => 'https://ssl.dotpay.pl/test_payment/',
+    'lang'       => 'pl',
+    'apiVersion' => 'dev',
+    'channel'    => '0'
+]);
+```
+
+```php
+// Omnipay generic parameters
+$params = [
+    'amount' => 12.34,
+    'currency' => 'PLN',
+    'description' => 'Test payment',
+    'returnUrl' => 'https://www.your-domain.nl/return_here',
+    'notifyUrl' => 'https://www.your-domain.nl/notify_here',
+    'email' => 'customer_email@example.com',
+];
+
+// You can add Dotpay-specific (not Omnipay generic) parameters here:
+$params += [
+    'first_name' => 'Jan',
+    'last_name' => 'Kowalski',
+];
+
+$response = $gateway
+    ->purchase($params)
+    ->send();
+
+if ($response->isRedirect()) {
+    $response->redirect();
+} else if ($response->isSuccessful()) {
+    // process payment
+} else {
+    // process failure
+}
+```

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "omnipay/common": "~3.0"
     },
     "require-dev": {
-        "omnipay/tests": "~3.0"
+        "omnipay/tests": "~3.0",
+        "squizlabs/php_codesniffer": "3.*"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "omnipay/dotpay",
+    "name": "ptuchik/omnipay-dotpay",
     "type": "library",
     "description": "Dotpay driver for the Omnipay payment processing library",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ptuchik/omnipay-dotpay",
+    "name": "omnipay/dotpay",
     "type": "library",
     "description": "Dotpay driver for the Omnipay payment processing library",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
         "psr-4": { "Omnipay\\Dotpay\\" : "src/" }
     },
     "require": {
-        "omnipay/common": "~2.0"
+        "omnipay/common": "~3.0"
     },
     "require-dev": {
-        "omnipay/tests": "~2.0"
+        "omnipay/tests": "~3.0"
     },
     "extra": {
         "branch-alias": {

--- a/src/ChkGenerator.php
+++ b/src/ChkGenerator.php
@@ -69,4 +69,31 @@ class ChkGenerator
 
         return hash('sha256', $chain);
     }
+
+    public static function generateSignature($pid, $params)
+    {
+        $chain = $pid.
+            (isset($params['id']) ? $params['id'] : '').
+            (isset($params['operation_number']) ? $params['operation_number'] : '').
+            (isset($params['operation_type']) ? $params['operation_type'] : '').
+            (isset($params['operation_status']) ? $params['operation_status'] : '').
+            (isset($params['operation_amount']) ? $params['operation_amount'] : '').
+            (isset($params['operation_currency']) ? $params['operation_currency'] : '').
+            (isset($params['operation_withdrawal_amount']) ? $params['operation_withdrawal_amount'] : '').
+            (isset($params['operation_commission_amount']) ? $params['operation_commission_amount'] : '').
+            (isset($params['operation_original_amount']) ? $params['operation_original_amount'] : '').
+            (isset($params['operation_original_currency']) ? $params['operation_original_currency'] : '').
+            (isset($params['operation_datetime']) ? $params['operation_datetime'] : '').
+            (isset($params['operation_related_number']) ? $params['operation_related_number'] : '').
+            (isset($params['control']) ? $params['control'] : '').
+            (isset($params['description']) ? $params['description'] : '').
+            (isset($params['email']) ? $params['email'] : '').
+            (isset($params['p_info']) ? $params['p_info'] : '').
+            (isset($params['p_email']) ? $params['p_email'] : '').
+            (isset($params['channel']) ? $params['channel'] : '').
+            (isset($params['channel_country']) ? $params['channel_country'] : '').
+            (isset($params['geoip_country']) ? $params['geoip_country'] : '');
+
+        return hash('sha256', $chain);
+    }
 }

--- a/src/ChkGenerator.php
+++ b/src/ChkGenerator.php
@@ -1,0 +1,72 @@
+<?php
+
+
+namespace Omnipay\Dotpay;
+
+
+class ChkGenerator
+{
+    public static function generateChk($accountId, $pid, $params) {
+        $params['id'] = $accountId;
+        $chain =
+            $pid.
+            (isset($params['api_version']) ? $params['api_version'] : null).
+            (isset($params['charset']) ? $params['charset'] : null).
+            (isset($params['lang']) ? $params['lang'] : null).
+            (isset($params['id']) ? $params['id'] : null).
+            (isset($params['amount']) ? $params['amount'] : null).
+            (isset($params['currency']) ? $params['currency'] : null).
+            (isset($params['description']) ? $params['description'] : null).
+            (isset($params['control']) ? $params['control'] : null).
+            (isset($params['channel']) ? $params['channel'] : null).
+            (isset($params['credit_card_brand']) ? $params['credit_card_brand'] : null).
+            (isset($params['ch_lock']) ? $params['ch_lock'] : null).
+            (isset($params['channel_groups']) ? $params['channel_groups'] : null).
+            (isset($params['onlinetransfer']) ? $params['onlinetransfer'] : null).
+            (isset($params['URL']) ? $params['URL'] : null).
+            (isset($params['type']) ? $params['type'] : null).
+            (isset($params['buttontext']) ? $params['buttontext'] : null).
+            (isset($params['URLC']) ? $params['URLC'] : null).
+            (isset($params['firstname']) ? $params['firstname'] : null).
+            (isset($params['lastname']) ? $params['lastname'] : null).
+            (isset($params['email']) ? $params['email'] : null).
+            (isset($params['street']) ? $params['street'] : null).
+            (isset($params['street_n1']) ? $params['street_n1'] : null).
+            (isset($params['street_n2']) ? $params['street_n2'] : null).
+            (isset($params['state']) ? $params['state'] : null).
+            (isset($params['addr3']) ? $params['addr3'] : null).
+            (isset($params['city']) ? $params['city'] : null).
+            (isset($params['postcode']) ? $params['postcode'] : null).
+            (isset($params['phone']) ? $params['phone'] : null).
+            (isset($params['country']) ? $params['country'] : null).
+            (isset($params['code']) ? $params['code'] : null).
+            (isset($params['p_info']) ? $params['p_info'] : null).
+            (isset($params['p_email']) ? $params['p_email'] : null).
+            (isset($params['n_email']) ? $params['n_email'] : null).
+            (isset($params['expiration_date']) ? $params['expiration_date'] : null).
+            (isset($params['recipient_account_number']) ? $params['recipient_account_number'] : null).
+            (isset($params['recipient_company']) ? $params['recipient_company'] : null).
+            (isset($params['recipient_first_name']) ? $params['recipient_first_name'] : null).
+            (isset($params['recipient_last_name']) ? $params['recipient_last_name'] : null).
+            (isset($params['recipient_address_street']) ? $params['recipient_address_street'] : null).
+            (isset($params['recipient_address_building']) ? $params['recipient_address_building'] : null).
+            (isset($params['recipient_address_apartment']) ? $params['recipient_address_apartment'] : null).
+            (isset($params['recipient_address_postcode']) ? $params['recipient_address_postcode'] : null).
+            (isset($params['recipient_address_city']) ? $params['recipient_address_city'] : null).
+            (isset($params['warranty']) ? $params['warranty'] : null).
+            (isset($params['bylaw']) ? $params['bylaw'] : null).
+            (isset($params['personal_data']) ? $params['personal_data'] : null).
+            (isset($params['credit_card_number']) ? $params['credit_card_number'] : null).
+            (isset($params['credit_card_expiration_date_year']) ? $params['credit_card_expiration_date_year'] : null).
+            (isset($params['credit_card_expiration_date_month']) ? $params['credit_card_expiration_date_month'] : null).
+            (isset($params['credit_card_security_code']) ? $params['credit_card_security_code'] : null).
+            (isset($params['credit_card_store']) ? $params['credit_card_store'] : null).
+            (isset($params['credit_card_store_security_code']) ? $params['credit_card_store_security_code'] : null).
+            (isset($params['credit_card_customer_id']) ? $params['credit_card_customer_id'] : null).
+            (isset($params['credit_card_id']) ? $params['credit_card_id'] : null).
+            (isset($params['blik_code']) ? $params['blik_code'] : null).
+            (isset($params['credit_card_registration']) ? $params['credit_card_registration'] : null);
+
+        return hash('sha256', $chain);
+    }
+}

--- a/src/ChkGenerator.php
+++ b/src/ChkGenerator.php
@@ -3,10 +3,10 @@
 
 namespace Omnipay\Dotpay;
 
-
 class ChkGenerator
 {
-    public static function generateChk($accountId, $pid, $params) {
+    public static function generateChk($accountId, $pid, $params)
+    {
         $params['id'] = $accountId;
         $chain =
             $pid.

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -18,7 +18,7 @@ class Gateway extends AbstractGateway
     const PAYMENT_REDIRECT_NONE_TYPE = 2;
     const PAYMENT_BUTTON_BACK_AND_POST_REQUEST_TYPE = 3;
     const PAYMENT_REDIRECT_TYPE = 4;
-    
+
     /**
      * Return name of gateway.
      * @return string

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -213,6 +213,29 @@ class Gateway extends AbstractGateway
     }
 
     /**
+     * Get channel groups.
+     * @return mixed
+     */
+    public function getChannelGroups()
+    {
+        return $this->getParameter('channel_groups');
+    }
+
+    /**
+     * Set channel groups.
+     * More info in
+     * {@link https://ssl.dotpay.pl/s2/login/cloudfs1/magellan_media/common_file/55acab1fdadfce6f45d351ee/dotpay_instrukcja_techniczna_1.23.9.1_pl.pdf Dotpay documentation }
+     *
+     * @param $value
+     *
+     * @return $this
+     */
+    public function setChannelGroups($value)
+    {
+        return $this->setParameter('channel_groups', $value);
+    }
+
+    /**
      * @inheritdoc
      *
      * @param array $parameters

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -9,7 +9,7 @@ use Omnipay\Dotpay\Message\Request;
 
 /**
  * Dotpay Gateway.
- * @link https://ssl.dotpay.pl/s2/login/cloudfs1/magellan_media/common_file/55acab1fdadfce6f45d351ee/dotpay_instrukcja_techniczna_1.23.9.1_pl.pdf
+ * @link http://www.dotpay.pl/dla-developerow/
  */
 class Gateway extends AbstractGateway
 {
@@ -200,8 +200,6 @@ class Gateway extends AbstractGateway
 
     /**
      * Set channel payment.
-     * More info in
-     * {@link https://ssl.dotpay.pl/s2/login/cloudfs1/magellan_media/common_file/55acab1fdadfce6f45d351ee/dotpay_instrukcja_techniczna_1.23.9.1_pl.pdf Dotpay documentation }
      *
      * @param $value
      *
@@ -223,8 +221,6 @@ class Gateway extends AbstractGateway
 
     /**
      * Set channel groups.
-     * More info in
-     * {@link https://ssl.dotpay.pl/s2/login/cloudfs1/magellan_media/common_file/55acab1fdadfce6f45d351ee/dotpay_instrukcja_techniczna_1.23.9.1_pl.pdf Dotpay documentation }
      *
      * @param $value
      *

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -3,18 +3,18 @@
 namespace Omnipay\Dotpay;
 
 use Omnipay\Common\AbstractGateway;
+use Omnipay\Dotpay\Message\CompletePurchaseRequest;
 use Omnipay\Dotpay\Message\PurchaseRequest;
+use Omnipay\Dotpay\Message\Request;
 
 /**
  * Dotpay Gateway.
- *
  * @link https://ssl.dotpay.pl/s2/login/cloudfs1/magellan_media/common_file/55acab1fdadfce6f45d351ee/dotpay_instrukcja_techniczna_1.23.9.1_pl.pdf
  */
 class Gateway extends AbstractGateway
 {
     /**
      * Return name of gateway.
-     *
      * @return string
      */
     public function getName()
@@ -29,19 +29,18 @@ class Gateway extends AbstractGateway
     public function getDefaultParameters()
     {
         return array(
-            'accountId' => '',
-            'pid' => '',
-            'type' => '0',
-            'action' => 'https://ssl.dotpay.pl/test_payment/',
-            'lang' => 'pl',
+            'accountId'  => '',
+            'pid'        => '',
+            'type'       => '0',
+            'action'     => 'https://ssl.dotpay.pl/test_payment/',
+            'lang'       => 'pl',
             'apiVersion' => 'dev',
-            'channel' => 123
+            'channel'    => 123
         );
     }
 
     /**
      * Return account ID in Dotpay service.
-     *
      * @return int
      */
     public function getAccountId()
@@ -55,6 +54,7 @@ class Gateway extends AbstractGateway
      * maximal value 999999
      *
      * @param $value
+     *
      * @return $this
      */
     public function setAccountId($value)
@@ -64,7 +64,6 @@ class Gateway extends AbstractGateway
 
     /**
      * Get PIN for Dotpay.
-     *
      * @return string
      */
     public function getPid()
@@ -76,6 +75,7 @@ class Gateway extends AbstractGateway
      * Set PIN for Dotpay.
      *
      * @param $value
+     *
      * @return $this
      */
     public function setPid($value)
@@ -85,7 +85,6 @@ class Gateway extends AbstractGateway
 
     /**
      * Get `type` parametr for Dotpay service.
-     *
      * @return mixed
      */
     public function getType()
@@ -98,14 +97,12 @@ class Gateway extends AbstractGateway
      * Value of parameter affects the behavior of the {@link setReturnUrl()} parameter.
      * Available values:
      * 0 - After payment, the Purchaser will be made available return to the site of the Seller,
-     * 1 - After payment created an implicit connection to the Buyer. The address in the URL parameter will be sent (POST)
-     * the data presented in the chapter. AFTER RECEIVING PAYMENT INFORMATION (NOTICE URLC).
+     * 1 - After payment created an implicit connection to the Buyer. The address in the URL parameter will be sent
+     * (POST) the data presented in the chapter. AFTER RECEIVING PAYMENT INFORMATION (NOTICE URLC).
      * 2 - No response, nothing is sent, the lack of a button (default).
-     * 3 - shares will be performed for type = 0, and type = 1, ie. Both will be uploads the data presented in the chapter.
-     * AFTER RECEIVING INFORMATION
-     * PAYMENT (NOTIFICATION URLC) in conjunction closed (by POST) and displays the return to service
-     * Seller. If you use a notification mechanism
-     * URLC no need to use this value.
+     * 3 - shares will be performed for type = 0, and type = 1, ie. Both will be uploads the data presented in the
+     * chapter. AFTER RECEIVING INFORMATION PAYMENT (NOTIFICATION URLC) in conjunction closed (by POST) and displays
+     * the return to service Seller. If you use a notification mechanism URLC no need to use this value.
      * 4 - You will be redirected to the direct channel provider of payment
      * (Eg. The Bank), as well as the payment and logout
      * in the service provider channel Buyer will be redirected
@@ -114,6 +111,7 @@ class Gateway extends AbstractGateway
      * the payment channel and the respective side configuration dotpay.
      *
      * @param $value
+     *
      * @return $this
      */
     public function setType($value)
@@ -123,7 +121,6 @@ class Gateway extends AbstractGateway
 
     /**
      * Get url to Dotpay service.
-     *
      * @return mixed
      */
     public function getAction()
@@ -135,6 +132,7 @@ class Gateway extends AbstractGateway
      * Set url to Dotpay service.
      *
      * @param $value
+     *
      * @return $this
      */
     public function setAction($value)
@@ -144,7 +142,6 @@ class Gateway extends AbstractGateway
 
     /**
      * Set language for payment.
-     *
      * @return mixed
      */
     public function getLang()
@@ -156,6 +153,7 @@ class Gateway extends AbstractGateway
      * Get language of payment.
      *
      * @param $value
+     *
      * @return $this
      */
     public function setLang($value)
@@ -165,7 +163,6 @@ class Gateway extends AbstractGateway
 
     /**
      * Set api version.
-     *
      * @return mixed
      */
     public function getApiVersion()
@@ -178,6 +175,7 @@ class Gateway extends AbstractGateway
      * Default value is 'dev'.
      *
      * @param $value
+     *
      * @return $this
      */
     public function setApiVersion($value)
@@ -187,7 +185,6 @@ class Gateway extends AbstractGateway
 
     /**
      * Get channel payment.
-     *
      * @return mixed
      */
     public function getChannel()
@@ -197,9 +194,11 @@ class Gateway extends AbstractGateway
 
     /**
      * Set channel payment.
-     * More info in {@link https://ssl.dotpay.pl/s2/login/cloudfs1/magellan_media/common_file/55acab1fdadfce6f45d351ee/dotpay_instrukcja_techniczna_1.23.9.1_pl.pdf Dotpay documentation }
+     * More info in
+     * {@link https://ssl.dotpay.pl/s2/login/cloudfs1/magellan_media/common_file/55acab1fdadfce6f45d351ee/dotpay_instrukcja_techniczna_1.23.9.1_pl.pdf Dotpay documentation }
      *
      * @param $value
+     *
      * @return $this
      */
     public function setChannel($value)
@@ -209,21 +208,25 @@ class Gateway extends AbstractGateway
 
     /**
      * @inheritdoc
+     *
      * @param array $parameters
+     *
      * @return \Omnipay\Common\Message\AbstractRequest
      */
     public function purchase(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\Dotpay\Message\Request', $parameters);
+        return $this->createRequest(Request::class, $parameters);
     }
 
     /**
      * @inheritdoc
+     *
      * @param array $parameters
+     *
      * @return \Omnipay\Common\Message\AbstractRequest
      */
     public function completePurchase(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\Dotpay\Message\CompletePurchaseRequest', $parameters);
+        return $this->createRequest(CompletePurchaseRequest::class, $parameters);
     }
 }

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -13,6 +13,12 @@ use Omnipay\Dotpay\Message\Request;
  */
 class Gateway extends AbstractGateway
 {
+    const PAYMENT_BUTTON_BACK_TYPE = 0;
+    const PAYMENT_BACK_POST_REQUEST_TYPE = 1;
+    const PAYMENT_REDIRECT_NONE_TYPE = 2;
+    const PAYMENT_BUTTON_BACK_AND_POST_REQUEST_TYPE = 3;
+    const PAYMENT_REDIRECT_TYPE = 4;
+    
     /**
      * Return name of gateway.
      * @return string

--- a/src/Message/CompletePurchaseRequest.php
+++ b/src/Message/CompletePurchaseRequest.php
@@ -2,6 +2,8 @@
 
 namespace Omnipay\Dotpay\Message;
 
+use Omnipay\Dotpay\ChkGenerator;
+
 /**
  * Dotpay Complete Purchase Request.
  */
@@ -25,8 +27,20 @@ class CompletePurchaseRequest extends Request
      */
     public function sendData($data)
     {
-        $data['pid'] = $this->getPid();
+        $signatureValid = $this->validateSignature($data);
+        return $this->response = new CompletePurchaseResponse($this, $data, $signatureValid);
+    }
 
-        return $this->response = new CompletePurchaseResponse($this, $data);
+    /**
+     * Validate signature from Dotpay response
+     * and return transaction status.
+     *
+     * @param array $data
+     *
+     * @return bool
+     */
+    private function validateSignature($data)
+    {
+        return ChkGenerator::generateSignature($this->getPid(), $data) === $data['signature'];
     }
 }

--- a/src/Message/CompletePurchaseRequest.php
+++ b/src/Message/CompletePurchaseRequest.php
@@ -9,7 +9,6 @@ class CompletePurchaseRequest extends Request
 {
     /**
      * @inheritdoc
-     *
      * @return mixed
      */
     public function getData()
@@ -21,6 +20,7 @@ class CompletePurchaseRequest extends Request
      * @inheritdoc
      *
      * @param mixed $data
+     *
      * @return CompletePurchaseResponse
      */
     public function sendData($data)

--- a/src/Message/CompletePurchaseResponse.php
+++ b/src/Message/CompletePurchaseResponse.php
@@ -82,6 +82,6 @@ class CompletePurchaseResponse extends AbstractResponse
      */
     public function getTransactionReference()
     {
-        return $this->data['operation_number'] ?? '';
+        return isset($this->data['operation_number']) ? $this->data['operation_number'] : '';
     }
 }

--- a/src/Message/CompletePurchaseResponse.php
+++ b/src/Message/CompletePurchaseResponse.php
@@ -29,33 +29,35 @@ class CompletePurchaseResponse extends AbstractResponse
      * and return transaction status.
      *
      * @param array $data
+     *
      * @return OK | FAIL string
      */
     public function validateSignature($data)
     {
-        $string = $data['pid'] .
-            (isset($data['id']) ? $data['id'] : '') .
-            (isset($data['operation_number']) ? $data['operation_number'] : '') .
-            (isset($data['operation_type']) ? $data['operation_type'] : '') .
-            (isset($data['operation_status']) ? $data['operation_status'] : '') .
-            (isset($data['operation_amount']) ? $data['operation_amount'] : '') .
-            (isset($data['operation_currency']) ? $data['operation_currency'] : '') .
-            (isset($data['operation_withdrawal_amount']) ? $data['operation_withdrawal_amount'] : '') .
-            (isset($data['operation_commission_amount']) ? $data['operation_commission_amount'] : '') .
-            (isset($data['operation_original_amount']) ? $data['operation_original_amount'] : '') .
-            (isset($data['operation_original_currency']) ? $data['operation_original_currency'] : '') .
-            (isset($data['operation_datetime']) ? $data['operation_datetime'] : '') .
-            (isset($data['operation_related_number']) ? $data['operation_related_number'] : '') .
-            (isset($data['control']) ? $data['control'] : '') .
-            (isset($data['description']) ? $data['description'] : '') .
-            (isset($data['email']) ? $data['email'] : '') .
-            (isset($data['p_info']) ? $data['p_info'] : '') .
-            (isset($data['p_email']) ? $data['p_email'] : '') .
-            (isset($data['channel']) ? $data['channel'] : '') .
-            (isset($data['channel_country']) ? $data['channel_country'] : '') .
+        $string = $data['pid'].
+            (isset($data['id']) ? $data['id'] : '').
+            (isset($data['operation_number']) ? $data['operation_number'] : '').
+            (isset($data['operation_type']) ? $data['operation_type'] : '').
+            (isset($data['operation_status']) ? $data['operation_status'] : '').
+            (isset($data['operation_amount']) ? $data['operation_amount'] : '').
+            (isset($data['operation_currency']) ? $data['operation_currency'] : '').
+            (isset($data['operation_withdrawal_amount']) ? $data['operation_withdrawal_amount'] : '').
+            (isset($data['operation_commission_amount']) ? $data['operation_commission_amount'] : '').
+            (isset($data['operation_original_amount']) ? $data['operation_original_amount'] : '').
+            (isset($data['operation_original_currency']) ? $data['operation_original_currency'] : '').
+            (isset($data['operation_datetime']) ? $data['operation_datetime'] : '').
+            (isset($data['operation_related_number']) ? $data['operation_related_number'] : '').
+            (isset($data['control']) ? $data['control'] : '').
+            (isset($data['description']) ? $data['description'] : '').
+            (isset($data['email']) ? $data['email'] : '').
+            (isset($data['p_info']) ? $data['p_info'] : '').
+            (isset($data['p_email']) ? $data['p_email'] : '').
+            (isset($data['channel']) ? $data['channel'] : '').
+            (isset($data['channel_country']) ? $data['channel_country'] : '').
             (isset($data['geoip_country']) ? $data['geoip_country'] : '');
 
-        if (hash('sha256', $string) === $data['signature'] && $data['operation_status'] === self::OPERATION_STATUS_COMPLETED) {
+        if (hash('sha256', $string) === $data['signature'] &&
+            $data['operation_status'] === self::OPERATION_STATUS_COMPLETED) {
             return self::STATUS_OK;
         } else {
             return self::STATUS_FAIL;
@@ -64,7 +66,6 @@ class CompletePurchaseResponse extends AbstractResponse
 
     /**
      * @inheritdoc
-     *
      * @return bool
      */
     public function isSuccessful()
@@ -73,6 +74,6 @@ class CompletePurchaseResponse extends AbstractResponse
             $this->data['status'] = $this->validateSignature($this->data);
         }
 
-        return $this->data['status']===self::STATUS_OK ? true : false;
+        return $this->data['status'] === self::STATUS_OK ? true : false;
     }
 }

--- a/src/Message/CompletePurchaseResponse.php
+++ b/src/Message/CompletePurchaseResponse.php
@@ -76,4 +76,12 @@ class CompletePurchaseResponse extends AbstractResponse
 
         return $this->data['status'] === self::STATUS_OK ? true : false;
     }
+
+    /**
+     * @return string|null
+     */
+    public function getTransactionReference()
+    {
+        return $this->data['operation_number'] ?? '';
+    }
 }

--- a/src/Message/Request.php
+++ b/src/Message/Request.php
@@ -80,6 +80,16 @@ class Request extends AbstractRequest
         return $this->setParameter('channel', $value);
     }
 
+    public function getChannelGroups()
+    {
+        return $this->getParameter('channel_groups');
+    }
+
+    public function setChannelGroups($value)
+    {
+        return $this->setParameter('channel_groups', $value);
+    }
+
     public function getChLock()
     {
         return $this->getParameter('ch_lock');
@@ -260,36 +270,37 @@ class Request extends AbstractRequest
         $this->validate('amount');
 
         $data = array(
-            'id'          => (int) $this->getAccountId(),
-            'amount'      => (float) $this->getAmount(),
-            'currency'    => $this->getCurrency(),
+            'id' => (int)$this->getAccountId(),
+            'amount' => (float)$this->getAmount(),
+            'currency' => $this->getCurrency(),
             'description' => $this->getDescription(),
-            'lang'        => $this->getLang(),
+            'lang' => $this->getLang(),
             'api_version' => $this->getApiVersion()
         );
 
         $additional = array(
-            'channel'    => $this->getChannel(),
-            'ch_lock'    => $this->getChLock(),
-            'URL'        => $this->getReturnUrl(),
-            'type'       => (string) $this->getType(),
+            'channel' => $this->getChannel(),
+            'channel_groups' => $this->getChannelGroups(),
+            'ch_lock' => $this->getChLock(),
+            'URL' => $this->getReturnUrl(),
+            'type' => (string)$this->getType(),
             'buttontext' => $this->getButtonText(),
-            'URLC'       => $this->getNotifyUrl(),
-            'control'    => $this->getControl(),
-            'firstname'  => $this->getFirstName(),
-            'lastname'   => $this->getLastName(),
-            'email'      => $this->getEmail(),
-            'street'     => $this->getStreet(),
-            'street_n1'  => $this->getStreetN1(),
-            'street_n2'  => $this->getStreetN2(),
-            'state'      => $this->getState(),
-            'addr3'      => $this->getAddr3(),
-            'city'       => $this->getCity(),
-            'postcode'   => $this->getPostcode(),
-            'phone'      => $this->getPhone(),
-            'country'    => $this->getCountry(),
-            'p_info'     => $this->getPInfo(),
-            'p_email'    => $this->getPEmail()
+            'URLC' => $this->getNotifyUrl(),
+            'control' => $this->getControl(),
+            'firstname' => $this->getFirstName(),
+            'lastname' => $this->getLastName(),
+            'email' => $this->getEmail(),
+            'street' => $this->getStreet(),
+            'street_n1' => $this->getStreetN1(),
+            'street_n2' => $this->getStreetN2(),
+            'state' => $this->getState(),
+            'addr3' => $this->getAddr3(),
+            'city' => $this->getCity(),
+            'postcode' => $this->getPostcode(),
+            'phone' => $this->getPhone(),
+            'country' => $this->getCountry(),
+            'p_info' => $this->getPInfo(),
+            'p_email' => $this->getPEmail()
         );
 
         foreach ($additional as $key => $value) {

--- a/src/Message/Request.php
+++ b/src/Message/Request.php
@@ -3,6 +3,7 @@
 namespace Omnipay\Dotpay\Message;
 
 use Omnipay\Common\Message\AbstractRequest;
+use Omnipay\Dotpay\ChkGenerator;
 
 /**
  * Dotpay Purchase Request.
@@ -296,6 +297,8 @@ class Request extends AbstractRequest
                 $data[$key] = $value;
             }
         }
+
+        $data['chk'] = ChkGenerator::generateChk($this->getAccountId(), $this->getPid(), $data);
 
         return $data;
     }

--- a/src/Message/Request.php
+++ b/src/Message/Request.php
@@ -287,7 +287,7 @@ class Request extends AbstractRequest
             'postcode'   => $this->getPostcode(),
             'phone'      => $this->getPhone(),
             'country'    => $this->getCountry(),
-            'p_info'     => (int) $this->getAccountId(),
+            'p_info'     => $this->getPInfo(),
             'p_email'    => $this->getPEmail()
         );
 

--- a/src/Message/Request.php
+++ b/src/Message/Request.php
@@ -254,50 +254,45 @@ class Request extends AbstractRequest
         return $this->getParameter('status');
     }
 
-    public function purchase(array $parameters = array())
-    {
-        return $this->createRequest('\Omnipay\TwoCheckout\Message\Request', $parameters);
-    }
-
     public function getData()
     {
         $this->validate('amount');
 
         $data = array(
-            'id' => (int) $this->getAccountId(),
-            'amount' => (float) $this->getAmount(),
-            'currency' => $this->getCurrency(),
+            'id'          => (int) $this->getAccountId(),
+            'amount'      => (float) $this->getAmount(),
+            'currency'    => $this->getCurrency(),
             'description' => $this->getDescription(),
-            'lang' => $this->getLang(),
+            'lang'        => $this->getLang(),
             'api_version' => $this->getApiVersion()
         );
 
         $additional = array(
-            'channel' => $this->getChannel(),
-            'ch_lock' => $this->getChLock(),
-            'URL' => $this->getReturnUrl(),
-            'type' => (string) $this->getType(),
+            'channel'    => $this->getChannel(),
+            'ch_lock'    => $this->getChLock(),
+            'URL'        => $this->getReturnUrl(),
+            'type'       => (string) $this->getType(),
             'buttontext' => $this->getButtonText(),
-            'URLC' => $this->getNotifyUrl(),
-            'control' => $this->getControl(),
-            'firstname' => $this->getFirstName(),
-            'lastname' => $this->getLastName(),
-            'email' => $this->getEmail(),
-            'street' => $this->getStreet(),
-            'street_n1' => $this->getStreetN1(),
-            'street_n2' => $this->getStreetN2(),
-            'state' => $this->getState(),
-            'addr3' => $this->getAddr3(),
-            'city' => $this->getCity(),
-            'postcode' => $this->getPostcode(),
-            'phone' => $this->getPhone(),
-            'country' => $this->getCountry(),
-            'p_info' => (int) $this->getAccountId(),
-            'p_email' => $this->getPEmail()
+            'URLC'       => $this->getNotifyUrl(),
+            'control'    => $this->getControl(),
+            'firstname'  => $this->getFirstName(),
+            'lastname'   => $this->getLastName(),
+            'email'      => $this->getEmail(),
+            'street'     => $this->getStreet(),
+            'street_n1'  => $this->getStreetN1(),
+            'street_n2'  => $this->getStreetN2(),
+            'state'      => $this->getState(),
+            'addr3'      => $this->getAddr3(),
+            'city'       => $this->getCity(),
+            'postcode'   => $this->getPostcode(),
+            'phone'      => $this->getPhone(),
+            'country'    => $this->getCountry(),
+            'p_info'     => (int) $this->getAccountId(),
+            'p_email'    => $this->getPEmail()
         );
 
         foreach ($additional as $key => $value) {
-            if ($value!='') {
+            if ($value != '') {
                 $data[$key] = $value;
             }
         }
@@ -305,7 +300,8 @@ class Request extends AbstractRequest
         return $data;
     }
 
-    public function getPostData() {
+    public function getPostData()
+    {
 
     }
 

--- a/src/Message/Request.php
+++ b/src/Message/Request.php
@@ -316,7 +316,6 @@ class Request extends AbstractRequest
 
     public function getPostData()
     {
-
     }
 
     public function sendData($data)

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -43,9 +43,14 @@ class GatewayTest extends GatewayTestCase
 
     public function testCompletePurchaseSuccess()
     {
+        $data = array(
+            'status' => 'OK',
+            'operation_number' => 'OPERATION-1',
+        );
+
         $this->getHttpRequest()->request->replace(
-            array(
-                'status'=>'OK'
+            $data + array(
+                'signature' => ChkGenerator::generateSignature($this->gateway->getPid(), $data),
             )
         );
 
@@ -53,7 +58,8 @@ class GatewayTest extends GatewayTestCase
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertEmpty($response->getTransactionReference());
-        $this->assertNull($response->getMessage());
+        $this->assertSame('OPERATION-1', $response->getTransactionReference());
+        $this->assertSame('OK', $response->getMessage());
+        $this->assertSame(200, $response->getCode());
     }
 }

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -1,11 +1,14 @@
 <?php
 
-namespace Omnipay\TwoCheckout;
+namespace Omnipay\Dotpay;
 
 use Omnipay\Tests\GatewayTestCase;
 
 class GatewayTest extends GatewayTestCase
 {
+    /** @var Gateway */
+    protected $gateway;
+
     public function setUp()
     {
         parent::setUp();
@@ -50,7 +53,7 @@ class GatewayTest extends GatewayTestCase
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertNull($response->getTransactionReference());
+        $this->assertEmpty($response->getTransactionReference());
         $this->assertNull($response->getMessage());
     }
 }

--- a/tests/Message/CompletePurchaseResponseTest.php
+++ b/tests/Message/CompletePurchaseResponseTest.php
@@ -2,33 +2,100 @@
 
 namespace Omnipay\Dotpay\Message;
 
+use Omnipay\Common\Message\NotificationInterface;
 use Omnipay\Tests\TestCase;
 
 class CompletePurchaseResponseTest extends TestCase
 {
+    const SIGNATURE_VALID = true;
+    const SIGNATURE_INVALID = false;
+
+    const OK_CODE = 200;
+    const OK_MESSAGE = 'OK';
+    const INVALID_CODE = 400;
+    const INVALID_MESSAGE = 'FAIL';
+
+    private $defaultParams = [
+        'status' => 'OK',
+        'pid' => '123456',
+        'operation_number' => 'OPERATION-1',
+    ];
+
     public function testConstruct()
     {
-        $response = new CompletePurchaseresponse($this->getMockRequest(), array('status' => 'OK','pid' => '123456'));
+        $response = new CompletePurchaseResponse($this->getMockRequest(), $this->defaultParams, self::SIGNATURE_VALID);
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertEmpty($response->getTransactionReference());
-        $this->assertNull($response->getMessage());
+
+        $this->assertSame('OPERATION-1', $response->getTransactionReference());
+
+        $this->assertSame(self::OK_MESSAGE, $response->getMessage());
+        $this->assertSame(self::OK_CODE, $response->getCode());
     }
 
-    public function testValidateSignature() {
-        $response = new CompletePurchaseresponse($this->getMockRequest(), array('status' => 'OK','pid' => '123456'));
+    public function testResponseWithValidSignature() {
+        $response = new CompletePurchaseResponse($this->getMockRequest(),
+            $this->defaultParams, self::SIGNATURE_VALID);
 
-        $data = array(
-            'pid' => '123456',
-            'id' => '123456',
-            'email' => 'test@test',
-            'operation_status' => 'completed'
-        );
+        $this->assertSame(self::OK_MESSAGE, $response->getMessage());
+        $this->assertSame(self::OK_CODE, $response->getCode());
+    }
 
-        $data['signature'] = hash('sha256', $data['pid'].$data['id'].$data['operation_status'].$data['email']);
+    public function testResponseWithInvalidSignature() {
+        $response = new CompletePurchaseResponse($this->getMockRequest(),
+            $this->defaultParams, self::SIGNATURE_INVALID);
 
-        $this->assertSame('OK', $response->validateSignature($data));
+        $this->assertSame(self::INVALID_MESSAGE, $response->getMessage());
+        $this->assertSame(self::INVALID_CODE, $response->getCode());
+    }
+
+    public function testResponseWithOperationStatusCompleted() {
+        $data = $this->defaultParams + [
+            'operation_status' => 'completed',
+        ];
+        $response = new CompletePurchaseResponse($this->getMockRequest(),
+            $data, self::SIGNATURE_VALID);
+
+        $this->assertSame(NotificationInterface::STATUS_COMPLETED, $response->getTransactionStatus());
+        $this->assertSame(self::OK_MESSAGE, $response->getMessage());
+        $this->assertSame(self::OK_CODE, $response->getCode());
+    }
+
+    public function testResponseWithOperationStatusRejected() {
+        $data = $this->defaultParams + [
+            'operation_status' => 'rejected',
+        ];
+        $response = new CompletePurchaseResponse($this->getMockRequest(),
+            $data, self::SIGNATURE_VALID);
+
+        $this->assertSame(NotificationInterface::STATUS_FAILED, $response->getTransactionStatus());
+        $this->assertSame(self::OK_MESSAGE, $response->getMessage());
+        $this->assertSame(self::OK_CODE, $response->getCode());
+    }
+
+    public function testResponseWithOperationStatusProcessingRealizationWaiting() {
+        $data = $this->defaultParams + [
+            'operation_status' => 'processing_realization_waiting',
+        ];
+        $response = new CompletePurchaseResponse($this->getMockRequest(),
+            $data, self::SIGNATURE_VALID);
+
+        $this->assertSame(NotificationInterface::STATUS_PENDING, $response->getTransactionStatus());
+        $this->assertSame(self::OK_MESSAGE, $response->getMessage());
+        $this->assertSame(self::OK_CODE, $response->getCode());
+    }
+
+    public function testResponseWithOperationStatusProcessingRealization() {
+        $data = $this->defaultParams + [
+            'operation_status' => 'processing_realization',
+        ];
+        $response = new CompletePurchaseResponse($this->getMockRequest(),
+            $data, self::SIGNATURE_VALID);
+
+        $this->assertSame(NotificationInterface::STATUS_PENDING, $response->getTransactionStatus());
+        $this->assertSame(self::OK_MESSAGE, $response->getMessage());
+        $this->assertSame(self::OK_CODE, $response->getCode());
     }
 
 }

--- a/tests/Message/CompletePurchaseResponseTest.php
+++ b/tests/Message/CompletePurchaseResponseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\TwoCheckout\Message;
+namespace Omnipay\Dotpay\Message;
 
 use Omnipay\Tests\TestCase;
 
@@ -12,7 +12,7 @@ class CompletePurchaseResponseTest extends TestCase
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertNull($response->getTransactionReference());
+        $this->assertEmpty($response->getTransactionReference());
         $this->assertNull($response->getMessage());
     }
 

--- a/tests/Message/RequestTest.php
+++ b/tests/Message/RequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\TwoCheckout\Message;
+namespace Omnipay\Dotpay\Message;
 
 use Omnipay\Tests\TestCase;
 
@@ -19,19 +19,20 @@ class RequestTest extends TestCase
         $request->setReturnUrl('http://example.com/return');
         $request->setNotifyUrl('http://example.com/notify');
         $request->setDescription('description for payment');
-        $request->setCurrency('YEN');
+        $request->setCurrency('JPY');
 
         $requestData = $request->getData();
 
         $this->assertEquals($requestData['id'], 123456);
         $this->assertEquals($requestData['amount'], 10.00);
-        $this->assertEquals($requestData['currency'], 'YEN');
+        $this->assertEquals($requestData['currency'], 'JPY');
         $this->assertEquals($requestData['description'], 'description for payment');
         $this->assertEquals($requestData['lang'], 'es');
         $this->assertEquals($requestData['type'], 100);
         $this->assertEquals($requestData['URL'], 'http://example.com/return');
         $this->assertEquals($requestData['URLC'], 'http://example.com/notify');
         $this->assertEquals($requestData['channel'], 321);
+        $this->assertEquals($requestData['chk'], 'c0f78147d4c64739fd3ad5e723b8434a10d90a9f4fc64b4cd3a5ba1df1f2e60c');
     }
 
     public function testGetAction()

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\TwoCheckout\Message;
+namespace Omnipay\Dotpay\Message;
 
 use Omnipay\Tests\TestCase;
 
@@ -10,7 +10,7 @@ class ResponseTest extends TestCase
     {
         $data = array('sid' => '12345', 'total' => '10.00');
 
-        $mock = $this->getMockBuilder('\Omnipay\TwoCheckout\Message\Request')
+        $mock = $this->getMockBuilder(Request::class)
             ->disableOriginalConstructor()
             ->getMock();
 


### PR DESCRIPTION
Note: Please merge https://github.com/dotpay/omnipay-dotpay/pull/3 and https://github.com/dotpay/omnipay-dotpay/pull/4 first.

Change covers:
* Implement `NotificationInterface` interface
* Properly return response code from `getCode()`
* Properly return response body from `getMessage()`

Example usage:
```php
$response = $gateway->completePurchase($params)
  ->send();

// handle result
if ($response->isSuccessful()) {
    if ($response->getTransactionStatus() === NotificationInterface::STATUS_PENDING) {
        // ...
    }
    if ($response->getTransactionStatus() === NotificationInterface::STATUS_FAILED) {
        // ...
    }
    if ($response->getTransactionStatus() === NotificationInterface::STATUS_COMPLETED) {
        // ...
    }
}

// framework-specific respose, Symfony example:
return Response::create($response->getMessage(), $response->getCode());
```
