### PR TITLE
Align omnipay-dotpay to omnipay 3.x version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ to your `composer.json` file:
 ```json
 {
     "require": {
-        "omnipay/dotpay": "~2.0"
+        "omnipay/dotpay": "~3.0"
     }
 }
 ```


### PR DESCRIPTION
:warning: After merge please put tag `3.0.0` on master to be able to download from Composer.

Closes #1 .